### PR TITLE
Fix userId lookup and time boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The following queries are written as if they were using [TQL](http://developer.t
 Query to get all of a user’s update records:
 
     METAQUERY
-        WHERE userid IS "12d7bc90fa"
+        WHERE userid IS 12d7bc90fa
 
     QUERY
         TYPE IN update
@@ -60,7 +60,7 @@ Query to get all of a user’s update records:
 Query to get a block of records in a given time range:
 
     METAQUERY
-        WHERE userid IS "12d7bc90fa"
+        WHERE userid IS 12d7bc90fa
 
     QUERY
         TYPE IN cbg, smbg, bolus, wizard

--- a/api/query.go
+++ b/api/query.go
@@ -35,6 +35,13 @@ func (a *Api) Query(res http.ResponseWriter, req *http.Request) {
 
 			} else {
 
+				if pair := a.SeagullClient.GetPrivatePair(qd.MetaQuery["userid"], "uploads", a.ShorelineClient.TokenProvide()); pair == nil {
+					res.WriteHeader(http.StatusInternalServerError)
+					return
+				} else {
+					qd.MetaQuery["userid"] = pair.ID
+				}
+
 				log.Printf("Query: data used [%v]", qd)
 
 				result := a.Store.ExecuteQuery(qd)

--- a/model/query.go
+++ b/model/query.go
@@ -83,7 +83,7 @@ func (qd *QueryData) buildWhere(raw string) error {
 				WhereCondition{
 					Name:      queryParts[whereIndex+1],
 					Condition: queryParts[whereIndex+2],
-					Value:     queryParts[whereIndex+3],
+					Value:     strings.ToUpper(queryParts[whereIndex+3]),
 				})
 
 			//do we also have an and?
@@ -93,7 +93,7 @@ func (qd *QueryData) buildWhere(raw string) error {
 					WhereCondition{
 						Name:      queryParts[andIndex+1],
 						Condition: queryParts[andIndex+2],
-						Value:     queryParts[andIndex+3],
+						Value:     strings.ToUpper(queryParts[andIndex+3]),
 					})
 			}
 		}

--- a/model/query_test.go
+++ b/model/query_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	VALID_QUERY     = "METAQUERY WHERE userid IS 12d7bc90fa QUERY TYPE IN update, cbg, smbg WHERE time > starttime AND time < endtime SORT BY time AS Timestamp REVERSED"
+	VALID_QUERY     = "METAQUERY WHERE userid IS 12d7bc90fa QUERY TYPE IN update, cbg, smbg WHERE time > 2015-01-01T00:00:00.000Z AND time < 2015-01-01T01:00:00.000Z SORT BY time AS Timestamp REVERSED"
 	IS_REVERSE      = "blah blah reversed"
 	IS_REVERSE_CASE = "blah blah REVERSED"
 	NOT_REVERSE     = "blah blah"
@@ -112,11 +112,11 @@ func TestQueryWhere(t *testing.T) {
 	first := qd.WhereConditons[0]
 	second := qd.WhereConditons[1]
 
-	if first.Name != "time" || first.Condition != ">" || first.Value != "starttime" {
+	if first.Name != "time" || first.Condition != ">" || first.Value != "2015-01-01T00:00:00.000Z" {
 		t.Fatalf("first where  %v doesn't match ", first)
 	}
 
-	if second.Name != "time" || second.Condition != "<" || second.Value != "endtime" {
+	if second.Name != "time" || second.Condition != "<" || second.Value != "2015-01-01T01:00:00.000Z" {
 		t.Fatalf("second where  %v doesn't match ", second)
 	}
 }


### PR DESCRIPTION
This PR has the fixes for userId lookup (octopus wasn't converting to the secret hash for the `groupId`) and it should make it so that time boundaries can actually be specified.

I updated the unit tests for the latter one, but I must admit that I didn't understand the unit tests for the former, so I have not much more than my own arbitrary belief in what the code will do to say whether or not this actually works...