### PR TITLE
Sprint 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Query to get all of a user’s update records:
 
     QUERY
         TYPE IN update
-        SORT BY time AS Timestamp REVERSED
 
 Query to get all of a user’s update records using the email address
 
@@ -79,7 +78,6 @@ Query to get all of a user’s update records using the email address
 
     QUERY
         TYPE IN update
-        SORT BY time AS Timestamp REVERSED
 
 Query to get a block of records in a given time range:
 
@@ -89,7 +87,6 @@ Query to get a block of records in a given time range:
     QUERY
         TYPE IN cbg, smbg, bolus, wizard
         WHERE time > starttime AND time < endtime
-        SORT BY time AS Timestamp REVERSED
 
 Query to get a block of records within a set of one or more upload IDs:
     METAQUERY
@@ -98,18 +95,16 @@ Query to get a block of records within a set of one or more upload IDs:
     QUERY
         TYPE IN cbg
         WHERE uploadId IN 4oiyhsdkh, 23498jsjsaf, ljlsadjfljasdf
-        SORT BY time AS Timestamp REVERSED
 
 You can also say NOT IN to reverse the sense of the test.
 
 You CANNOT currently combine the two types of WHERE clauses.
 
-
 Result will be a JSON array with individual records corresponding to the selected types, reverse sorted by date (from newest to oldest).
 
 The only acceptable `METAQUERY` is to query for a single userid. Aggregate metaqueries are not supported, and only the userids we give you will work.
 
-Results are sorted by the time field. `REVERSED` can be specified or omitted to control the sort, but you cannot sort by anything other than time (the rest of the sort clause is ignored).
+**NOTE:** Results are sorted by the `time` field.
 
 `TYPE IN` must be followed by a comma-separated list of types as defined in the [data formats documentation](http://developer.tidepool.io/data-model/v1/).
 

--- a/clients/mongoStoreClient.go
+++ b/clients/mongoStoreClient.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	DEVICE_DATA_COLLECTION = "deviceData"
-	sort_time              = "-time"
+	sort_time_descending   = "-time"
 )
 
 type MongoStoreClient struct {
@@ -69,21 +69,21 @@ func NewMongoStoreClient(config *StoreConfig) *MongoStoreClient {
 	//Note 1:  the order of the fields is important and should match query order
 	//Note 2:  '-time' is the field we are sorting on must be the last field in the index
 	queryIndex := mgo.Index{
-		Key:        []string{"_groupId", "_active", "_schemaVersion", "type", sort_time},
+		Key:        []string{"_groupId", "_active", "_schemaVersion", "type", sort_time_descending},
 		Background: true,
 	}
 	mongoSession.DB("").C(DEVICE_DATA_COLLECTION).EnsureIndex(queryIndex)
 
 	//As above but includes uploadId for restriction of data returned
 	queryUploadIdIndex := mgo.Index{
-		Key:        []string{"_groupId", "_active", "_schemaVersion", "type", "uploadId", sort_time},
+		Key:        []string{"_groupId", "_active", "_schemaVersion", "type", "uploadId", sort_time_descending},
 		Background: true,
 	}
 	mongoSession.DB("").C(DEVICE_DATA_COLLECTION).EnsureIndex(queryUploadIdIndex)
 
 	//time index used for sorts
 	timeIndex := mgo.Index{
-		Key:        []string{sort_time},
+		Key:        []string{sort_time_descending},
 		Background: true,
 	}
 	mongoSession.DB("").C(DEVICE_DATA_COLLECTION).EnsureIndex(timeIndex)
@@ -130,7 +130,7 @@ func (d MongoStoreClient) GetTimeLastEntryUser(groupId string) ([]byte, error) {
 	// Get the entry with the latest time by reverse sorting and taking the first value
 	err := sessionCopy.DB("").C(DEVICE_DATA_COLLECTION).
 		Find(d.getBaseQuery(groupId)).
-		Sort(sort_time).
+		Sort(sort_time_descending).
 		One(&result)
 
 	if err != nil {
@@ -152,7 +152,7 @@ func (d MongoStoreClient) GetTimeLastEntryUserAndDevice(groupId, deviceId string
 	// Get the entry with the latest time by reverse sorting and taking the first value
 	err := sessionCopy.DB("").C(DEVICE_DATA_COLLECTION).
 		Find(bson.M{"$and": []bson.M{d.getBaseQuery(groupId), bson.M{"deviceId": deviceId}}}).
-		Sort(sort_time).
+		Sort(sort_time_descending).
 		One(&result)
 
 	if err != nil {
@@ -232,7 +232,7 @@ func (d MongoStoreClient) ExecuteQuery(details *model.QueryData) ([]byte, error)
 
 	err := sessionCopy.DB("").C(DEVICE_DATA_COLLECTION).
 		Find(query).
-		Sort(sort_time). //we will always sort by time
+		Sort(sort_time_descending). //we will always sort by time
 		Select(filter).
 		All(&results)
 

--- a/clients/mongoStoreClient_test.go
+++ b/clients/mongoStoreClient_test.go
@@ -391,7 +391,6 @@ func Test_constructQuery_WhereQueryConstruction(t *testing.T) {
 		WhereConditions: []model.WhereCondition{model.WhereCondition{Name: "Stuff", Value: "123", Condition: ">"}},
 		Types:           []string{"cbg", "smbg"},
 		InList:          []string{},
-		Reverse:         false,
 	}
 
 	store := NewMongoStoreClient(initConfig(all_schemas))
@@ -430,7 +429,6 @@ func TestInQueryConstruction(t *testing.T) {
 		WhereConditions: []model.WhereCondition{model.WhereCondition{Name: "updateId", Value: "NOTHING", Condition: "IN"}},
 		Types:           []string{"cbg"},
 		InList:          []string{"firstId", "secondId"},
-		Reverse:         false,
 	}
 
 	store := NewMongoStoreClient(initConfig(all_schemas))

--- a/model/query.go
+++ b/model/query.go
@@ -37,7 +37,6 @@ type (
 		WhereConditions []WhereCondition
 		Types           []string
 		InList          []string
-		Reverse         bool
 	}
 	WhereCondition struct {
 		Name      string
@@ -169,17 +168,6 @@ func (qd *QueryData) buildInWhere(raw string) {
 	log.Printf("buildInWhere from [%s] shows incorrect or no where clause", raw)
 }
 
-func (qd *QueryData) buildOrder(raw string) {
-
-	qd.Reverse = false
-
-	if strings.Index(strings.ToLower(raw), "reverse") != -1 {
-		qd.Reverse = true
-	}
-
-	return
-}
-
 func BuildQuery(raw string) (parseErrs []error, qd *QueryData) {
 
 	qd = &QueryData{}
@@ -195,7 +183,6 @@ func BuildQuery(raw string) (parseErrs []error, qd *QueryData) {
 	} else if qd.isTimeWhere(raw) {
 		qd.buildTimeWhere(raw)
 	}
-	qd.buildOrder(raw)
 
 	return parseErrs, qd
 }

--- a/model/query_test.go
+++ b/model/query_test.go
@@ -106,8 +106,6 @@ func TestQueryWhereAnd(t *testing.T) {
 
 	qd.buildTimeWhere(QUERY_WHERE_AND)
 
-	t.Logf("%v", qd)
-
 	if len(qd.WhereConditions) != 2 {
 		t.Fatalf("there should be two where conditions got %v", qd.WhereConditions)
 	}

--- a/model/query_test.go
+++ b/model/query_test.go
@@ -22,10 +22,10 @@ import (
 )
 
 const (
-	QUERY_WHERE_AND  = "METAQUERY WHERE userid IS 12d7bc90fa QUERY TYPE IN update, cbg, smbg WHERE time > 2015-01-01T00:00:00.000Z AND time < 2015-01-01T01:00:00.000Z SORT BY time AS Timestamp REVERSED"
-	QUERY_WHERE      = "METAQUERY WHERE userid IS 12d7bc90fa QUERY TYPE IN update, cbg, smbg WHERE time >= 2015-01-01T00:00:00.000Z SORT BY time AS Timestamp REVERSED"
-	METAQUERY_EMAILS = "METAQUERY WHERE emails CONTAINS foo@bar.com QUERY TYPE IN update, cbg, smbg WHERE time >= 2015-01-01T00:00:00.000Z SORT BY time AS Timestamp REVERSED"
-	QUERY_WHERE_IN   = "METAQUERY WHERE userid IS 12d7bc90fa QUERY TYPE IN cbg WHERE updateId NOT IN abcd, efgh, ijkl SORT BY time AS Timestamp REVERSED"
+	QUERY_WHERE_AND  = "METAQUERY WHERE userid IS 12d7bc90fa QUERY TYPE IN update, cbg, smbg WHERE time > 2015-01-01T00:00:00.000Z AND time < 2015-01-01T01:00:00.000Z"
+	QUERY_WHERE      = "METAQUERY WHERE userid IS 12d7bc90fa QUERY TYPE IN update, cbg, smbg WHERE time >= 2015-01-01T00:00:00.000Z"
+	METAQUERY_EMAILS = "METAQUERY WHERE emails CONTAINS foo@bar.com QUERY TYPE IN update, cbg, smbg WHERE time >= 2015-01-01T00:00:00.000Z"
+	QUERY_WHERE_IN   = "METAQUERY WHERE userid IS 12d7bc90fa QUERY TYPE IN cbg WHERE updateId NOT IN abcd, efgh, ijkl"
 	IS_REVERSE       = "blah blah reversed"
 	IS_REVERSE_CASE  = "blah blah REVERSED"
 	NOT_REVERSE      = "blah blah"
@@ -126,7 +126,7 @@ func TestMetaQueryWhere_Emails(t *testing.T) {
 
 func TestMetaQueryWhere_Bad(t *testing.T) {
 
-	const METAQUERY_BAD = "METAQUERY WHERE bad IS wrong QUERY TYPE IN update, cbg, smbg WHERE time >= 2015-01-01T00:00:00.000Z SORT BY time AS Timestamp REVERSED"
+	const METAQUERY_BAD = "METAQUERY WHERE bad IS wrong QUERY TYPE IN update, cbg, smbg WHERE time >= 2015-01-01T00:00:00.000Z"
 
 	qd := &QueryData{}
 
@@ -143,6 +143,8 @@ func TestQueryWhereAnd(t *testing.T) {
 	qd := &QueryData{}
 
 	qd.buildTimeWhere(QUERY_WHERE_AND)
+
+	t.Logf("%v", qd)
 
 	if len(qd.WhereConditions) != 2 {
 		t.Fatalf("there should be two where conditions got %v", qd.WhereConditions)
@@ -236,28 +238,6 @@ func TestTypes(t *testing.T) {
 
 }
 
-func TestSort_GivesError_WhenNoSortBy(t *testing.T) {
-	qd := &QueryData{}
-
-	noSortErr := qd.buildSort("QUERY TYPE IN update, cbg, smbg AS Timestamp REVERSED")
-
-	if noSortErr.Error() != ERROR_SORT_REQUIRED {
-		t.Fatalf("got err [%s] expected err [%s]", noSortErr.Error(), ERROR_SORT_REQUIRED)
-	}
-
-}
-
-func TestSort_GivesError_WhenNoSortByAs(t *testing.T) {
-	qd := &QueryData{}
-
-	noSortAsErr := qd.buildSort("QUERY TYPE IN update, cbg, smbg SORT BY time")
-
-	if noSortAsErr.Error() != ERROR_SORT_REQUIRED {
-		t.Fatalf("got err [%s] expected err [%s]", noSortAsErr.Error(), ERROR_SORT_REQUIRED)
-	}
-
-}
-
 func TestBuildQuery_WithWhereAnd(t *testing.T) {
 
 	//lets test it all
@@ -286,10 +266,6 @@ func TestBuildQuery_WithWhereAnd(t *testing.T) {
 
 	if qd.Types[2] != "smbg" {
 		t.Fatalf("type should have been smbg but [%s]", qd.Types[2])
-	}
-
-	if qd.Reverse != true {
-		t.Fatalf("should be reversed")
 	}
 
 	if len(qd.WhereConditions) != 2 {
@@ -336,10 +312,6 @@ func TestBuildQuery_WithWhere(t *testing.T) {
 		t.Fatalf("type should have been smbg but [%s]", qd.Types[2])
 	}
 
-	if qd.Reverse != true {
-		t.Fatalf("should be reversed")
-	}
-
 	if len(qd.WhereConditions) != 1 {
 		t.Fatalf("there should be 1 conditions but got [%d]", len(qd.WhereConditions))
 	}
@@ -372,10 +344,6 @@ func TestBuildQuery_WithWhereIn(t *testing.T) {
 		t.Fatalf("type should have been cbg but [%s]", qd.Types[0])
 	}
 
-	if qd.Reverse != true {
-		t.Fatalf("should be reversed")
-	}
-
 	if len(qd.WhereConditions) != 1 {
 		t.Fatalf("there should be 1 conditions but got [%d]", len(qd.WhereConditions))
 	}
@@ -398,8 +366,8 @@ func TestExtractQueryData_AccumulatesErrors(t *testing.T) {
 
 	errs, _ := BuildQuery("blah blah")
 
-	if len(errs) != 3 {
-		t.Fatalf("there should be errors [%d]", len(errs))
+	if len(errs) != 2 {
+		t.Fatalf("there should be TWO errors but got [%d]", len(errs))
 	}
 
 }

--- a/model/query_test.go
+++ b/model/query_test.go
@@ -26,45 +26,7 @@ const (
 	QUERY_WHERE      = "METAQUERY WHERE userid IS 12d7bc90fa QUERY TYPE IN update, cbg, smbg WHERE time >= 2015-01-01T00:00:00.000Z"
 	METAQUERY_EMAILS = "METAQUERY WHERE emails CONTAINS foo@bar.com QUERY TYPE IN update, cbg, smbg WHERE time >= 2015-01-01T00:00:00.000Z"
 	QUERY_WHERE_IN   = "METAQUERY WHERE userid IS 12d7bc90fa QUERY TYPE IN cbg WHERE updateId NOT IN abcd, efgh, ijkl"
-	IS_REVERSE       = "blah blah reversed"
-	IS_REVERSE_CASE  = "blah blah REVERSED"
-	NOT_REVERSE      = "blah blah"
 )
-
-func TestReverse_True(t *testing.T) {
-	qd := &QueryData{}
-
-	qd.buildOrder(IS_REVERSE)
-
-	if qd.Reverse == false {
-		t.Fatalf(" reverse should have been true")
-	}
-
-}
-
-func TestReverse_False(t *testing.T) {
-	qd := &QueryData{}
-
-	qd.buildOrder(NOT_REVERSE)
-
-	if qd.Reverse == true {
-		t.Fatalf(" reverse should have been false")
-	}
-
-}
-
-func TestReverse_IgnoresCase(t *testing.T) {
-	qd1 := &QueryData{}
-	qd2 := &QueryData{}
-
-	qd1.buildOrder(IS_REVERSE)
-	qd2.buildOrder(IS_REVERSE_CASE)
-
-	if qd1.Reverse != qd2.Reverse {
-		t.Fatalf("should have the same result as we ignore case")
-	}
-
-}
 
 func TestMetaQuery_GivesError_WhenNoWhere(t *testing.T) {
 	qd := &QueryData{}

--- a/query_cli
+++ b/query_cli
@@ -53,7 +53,7 @@
 #
 # $ tp_query >output.txt
 # The query will be:
-# METAQUERY WHERE userid IS 467c4642d5 QUERY TYPE IN cbg WHERE time > 2014-08-20T00:00:00.000Z AND time < 2014-08-21T00:00:00.000Z SORT BY time AS Timestamp REVERSED
+# METAQUERY WHERE userid IS 467c4642d5 QUERY TYPE IN cbg WHERE time > 2014-08-20T00:00:00.000Z AND time < 2014-08-21T00:00:00.000Z
 
 # Enter to run the query or [c] to cancel:
 #   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
@@ -220,7 +220,7 @@ tp_query() {
         fi
     fi
 
-    QUERY="METAQUERY WHERE userid IS $TP_USERID QUERY TYPE IN $QUERY_TYPES $QUERY_WHERE SORT BY time AS Timestamp REVERSED"
+    QUERY="METAQUERY WHERE userid IS $TP_USERID QUERY TYPE IN $QUERY_TYPES $QUERY_WHERE"
 
     # send these prompts to stdout so that you can redirect the output of this
     # command to a file to save the result
@@ -249,7 +249,7 @@ tp_inquery() {
         QUERY_WHERE=$3
     fi
 
-    QUERY="METAQUERY WHERE userid IS $TP_USERID QUERY TYPE IN $QUERY_TYPES $QUERY_WHERE SORT BY time AS Timestamp REVERSED"
+    QUERY="METAQUERY WHERE userid IS $TP_USERID QUERY TYPE IN $QUERY_TYPES $QUERY_WHERE"
 
     # send these prompts to stdout so that you can redirect the output of this
     # command to a file to save the result


### PR DESCRIPTION
@darinkrauss not supper urgent but this will resolve https://trello.com/c/K2s05DSl

**Details:**

 - on large data sets the sort clause would fail as we didn't have an index on it.
 - all the queries are sorted by -time
 - the sort field and order was configurable BUT it was always used as the default 

**Changes:**

 - add an index for sorting on time
 - remove the ability to change the sort field. Then we can guard against missing another index 
 - remove the ability to change the sort order - again so we have the right index 